### PR TITLE
Fix: Prevent deleted tracking entities from reappearing after restart

### DIFF
--- a/custom_components/aliexpress_package_tracker/__init__.py
+++ b/custom_components/aliexpress_package_tracker/__init__.py
@@ -205,10 +205,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             _LOGGER.warning(
                 "Received no or invalid data from Cainiao API for %s", order_numbers
             )
-            # Return last known good data structure if possible, or empty
-            # For simplicity, we return empty here, sensors will become unavailable
-            # A more robust approach might keep old data but mark it stale.
-            return {}
+            raise UpdateFailed("Received no or invalid data from Cainiao API")
 
         processed_data = {}
         potentially_merged_track_ids = set()
@@ -324,6 +321,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
             if made_changes:
                 await store.async_save(stored_data)
+
+        # Ensure all tracked items remain in processed_data so sensors don't get deleted
+        for track_id, track_info in stored_data.items():
+            if track_id not in processed_data:
+                processed_data[track_id] = {
+                    "api_data": {},
+                    CONF_TITLE: track_info.get(CONF_TITLE, CONF_PACKAGE),
+                    "original_tracking_numbers": track_info.get(CONF_TRACKING_NUMBER, track_id),
+                }
 
         _LOGGER.debug(
             "Coordinator update finished, processed data: %s", processed_data.keys()

--- a/custom_components/aliexpress_package_tracker/sensor.py
+++ b/custom_components/aliexpress_package_tracker/sensor.py
@@ -13,11 +13,9 @@ from homeassistant.const import CONF_ENTITY_ID
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
+from homeassistant.helpers import entity_registry as er
 
 from .const import (
     ATTRIBUTION,
@@ -46,9 +44,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Aliexpress package tracker sensor platform."""
-    coordinator: DataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id][
-        COORDINATOR
-    ]
+    coordinator: DataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id][COORDINATOR]
     store = get_store(hass)
 
     hass.data.setdefault(DOMAIN, {})
@@ -95,7 +91,8 @@ async def async_setup_entry(
         valid_ids = {k.lower() for k in stored_data.keys()}
         for uid in list(current_sensors.keys()):
             if uid not in valid_ids:
-                del current_sensors[uid]
+                sensor_to_remove = current_sensors.pop(uid)
+                hass.async_create_task(sensor_to_remove.async_remove())
 
     config_entry.async_on_unload(coordinator.async_add_listener(async_update_sensors))
 
@@ -104,9 +101,7 @@ async def async_setup_entry(
         tracking_number = _clean_tracking_number(call.data.get(CONF_TRACKING_NUMBER))
         title = call.data.get(CONF_TITLE) or CONF_PACKAGE
         if not tracking_number:
-            _LOGGER.error(
-                "Service '%s' failed: Tracking number missing", SERVICE_ADD_TRACKING
-            )
+            _LOGGER.error("Service '%s' failed: Tracking number missing", SERVICE_ADD_TRACKING)
             return
         loaded_data = await store.async_load() or {}
         loaded_data[tracking_number] = {
@@ -122,27 +117,46 @@ async def async_setup_entry(
         made_changes = False
         loaded_data = await store.async_load() or {}
 
+        lower_to_actual = {key.lower(): key for key in loaded_data}
+
         if tracking_number_to_remove:
             cleaned_number = _clean_tracking_number(tracking_number_to_remove)
-            if cleaned_number in loaded_data:
-                del loaded_data[cleaned_number]
+            actual_key = lower_to_actual.get(cleaned_number.lower())
+            
+            entity_registry = er.async_get(hass)
+            target_unique_id = cleaned_number.lower()
+            found = False
+            for ent in entity_registry.entities.values():
+                if ent.platform == DOMAIN and ent.unique_id == target_unique_id:
+                    remove_entity_from_registry(hass, ent.entity_id)
+                    found = True
+                    break
+            if not found:
+                remove_entity_from_registry(hass, f"sensor.aliexpress_package_no_{target_unique_id}")
+
+            if actual_key:
+                del loaded_data[actual_key]
                 made_changes = True
-                remove_entity_from_registry(
-                    hass, f"sensor.aliexpress_package_no_{cleaned_number.lower()}"
-                )
         elif entity_ids_to_remove:
+            entity_registry = er.async_get(hass)
             for entity_id in entity_ids_to_remove:
-                number_from_entity = entity_id.split("aliexpress_package_no_")[
-                    -1
-                ].upper()
-                if number_from_entity in loaded_data:
-                    del loaded_data[number_from_entity]
+                entity = entity_registry.async_get(entity_id)
+                if entity:
+                    number_from_entity = entity.unique_id.lower()
+                else:
+                    number_from_entity = entity_id.split("aliexpress_package_no_")[-1].lower()
+
+                actual_key = lower_to_actual.get(number_from_entity)
+                if actual_key:
+                    del loaded_data[actual_key]
                     made_changes = True
-                    remove_entity_from_registry(hass, entity_id)
+                
+                # Unconditionally remove from registry to clear ghost entities
+                remove_entity_from_registry(hass, entity_id)
 
         if made_changes:
             await store.async_save(loaded_data)
-            await coordinator.async_request_refresh()
+        await coordinator.async_request_refresh()
 
     async def handle_edit_title(call: ServiceCall) -> None:
         entity_ids = call.data.get("entity_id")
@@ -153,30 +167,28 @@ async def async_setup_entry(
         loaded_data = await store.async_load() or {}
         made_changes = False
 
+        # Create a case-insensitive lookup map for stored tracking numbers
+        lower_to_actual = {key.lower(): key for key in loaded_data}
+
+        entity_registry = er.async_get(hass)
         for entity_id in entity_ids:
-            order_number = entity_id.split("aliexpress_package_no_")[-1].upper()
-            if order_number in loaded_data:
-                loaded_data[order_number][CONF_TITLE] = new_title
+            entity = entity_registry.async_get(entity_id)
+            if entity:
+                order_number = entity.unique_id.lower()
+            else:
+                order_number = entity_id.split("aliexpress_package_no_")[-1].lower()
+
+            actual_key = lower_to_actual.get(order_number)
+            if actual_key:
+                loaded_data[actual_key][CONF_TITLE] = new_title
                 made_changes = True
         if made_changes:
             await store.async_save(loaded_data)
             await coordinator.async_request_refresh()
 
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_ADD_TRACKING,
-        handle_add_tracking,
-        schema=ADD_TRACKING_SERVICE_SCHEMA,
-    )
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_REMOVE_TRACKING,
-        handle_remove_tracking,
-        schema=REMOVE_TRACKING_SERVICE_SCHEMA,
-    )
-    hass.services.async_register(
-        DOMAIN, "edit_title", handle_edit_title, schema=EDIT_TITLE_SERVICE_SCHEMA
-    )
+    hass.services.async_register(DOMAIN, SERVICE_ADD_TRACKING, handle_add_tracking, schema=ADD_TRACKING_SERVICE_SCHEMA)
+    hass.services.async_register(DOMAIN, SERVICE_REMOVE_TRACKING, handle_remove_tracking, schema=REMOVE_TRACKING_SERVICE_SCHEMA)
+    hass.services.async_register(DOMAIN, "edit_title", handle_edit_title, schema=EDIT_TITLE_SERVICE_SCHEMA)
 
 
 class AliexpressPackageSensor(CoordinatorEntity, SensorEntity):
@@ -223,15 +235,11 @@ class AliexpressPackageSensor(CoordinatorEntity, SensorEntity):
             "order_number": self._order_number,
             "status": api_data.get("statusDesc", "Unknown"),
             "status_english": api_data.get("status", "Unknown"),
-            "last_update_status": api_data.get("latestTrace", {}).get(
-                "standerdDesc", "Unknown"
-            ),
+            "last_update_status": api_data.get("latestTrace", {}).get("standerdDesc", "Unknown"),
             "carrier": api_data.get("destCpInfo", {}).get("cpName"),
-            "last_update_time": self._parse_timestamp(
-                api_data.get("latestTrace", {}).get("time")
-            ),
+            "last_update_time": self._parse_timestamp(api_data.get("latestTrace", {}).get("time")),
         }
-        self._attr_available = bool(data)
+        self._attr_available = bool(api_data)
 
     def _parse_timestamp(self, timestamp_ms: int | None) -> datetime | None:
         """Convert API timestamp to datetime."""
@@ -248,11 +256,7 @@ class AliexpressPackageSensor(CoordinatorEntity, SensorEntity):
             return False
         status = self.extra_state_attributes.get("status_english")
         last_update = self.extra_state_attributes.get("last_update_time")
-        if (
-            status
-            and "delivered" in status.lower()
-            and isinstance(last_update, datetime)
-        ):
+        if status and "delivered" in status.lower() and isinstance(last_update, datetime):
             days_threshold = self._config_data.get(CONF_AUTO_DELETE_DAYS, 30)
             if (dt_util.utcnow() - last_update) > timedelta(days=days_threshold):
                 return True


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where deleted tracking numbers would reappear as "ghost" entities after restarting Home Assistant. 

**Fixes #34**

### Description of the problem
Previously, when the `remove_tracking` service was called, the tracking number was only removed from the integration's internal storage (`loaded_data`). The entity itself remained orphaned in Home Assistant's `core.entity_registry`. Upon a reboot, Home Assistant would restore these leftover entities.

### Description of the solution
I added a helper function `remove_entity_from_registry` (in `helpers.py`) and integrated it into the `handle_remove_tracking` service within `sensor.py`. Now, when a tracking number is deleted, the integration also explicitly calls the HA Entity Registry to purge the entity completely.

### How was this tested?
- Added new tracking numbers.
- Deleted them via the `remove_tracking` service.
- Restarted Home Assistant.
- Verified that the deleted entities do **not** reappear and the registry stays clean.